### PR TITLE
feat: pass custom env vars from workflow to deploy commands

### DIFF
--- a/.github/workflows/reusable-deploy.yml
+++ b/.github/workflows/reusable-deploy.yml
@@ -29,10 +29,17 @@ on:
         required: true
         type: string
       runs_on:
-        description: 'Runner label to use for this deployment (optional)' 
+        description: 'Runner label to use for this deployment (optional)'
         required: false
         type: string
         default: 'ubuntu-latest'
+      # Custom env vars: pass as "KEY=VALUE KEY2=VALUE2" — each becomes
+      # DEPLOY_<KEY> in deploy commands (e.g. "mode=external-only" → $DEPLOY_mode).
+      env_vars:
+        description: 'Space-separated KEY=VALUE pairs (e.g. "mode=external-only services=notifications")'
+        required: false
+        type: string
+        default: ''
     secrets:
       KEY_FILE_FOR_DEPLOY:
         required: true
@@ -49,12 +56,25 @@ jobs:
           REPOSITORY: ${{ inputs.repository }}
           COMMIT_SHA: ${{ inputs.commit_sha }}
           COMMIT_AUTHOR: ${{ inputs.commit_author }}
+          ENV_VARS: ${{ inputs.env_vars }}
         run: |
           set -e  # Exit if any command fails
-          
+
           # Convert comma-separated URLs into array
           IFS=',' read -ra URLS <<< "$AUTODEPLOY_URL"
-          
+
+          # Build extra query params from ENV_VARS (e.g. "mode=external-only|services=notifications group-messages-bridge"
+          # becomes "env_mode=external-only&env_services=notifications%20group-messages-bridge")
+          extra_params=""
+          if [ -n "$ENV_VARS" ]; then
+            while IFS='=' read -r key value; do
+              if [ -n "$key" ] && [ -n "$value" ]; then
+                value_encoded=$(printf '%s' "$value" | sed 's/+/%%20/g; s/ /+/g')
+                extra_params="${extra_params}&env_${key}=${value_encoded}"
+              fi
+            done <<< "$(echo "$ENV_VARS" | tr '|' '\n')"
+          fi
+
           echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
           echo "🚀 Starting deployment to ${#URLS[@]} instance(s)"
           echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
@@ -88,7 +108,7 @@ jobs:
             # ============================================
             
             echo "📤 Starting deployment in background..."
-            deployment_url="https://${INSTANCE_URL}?repo=${REPOSITORY}&key=${KEY_FILE_FOR_DEPLOY}"
+            deployment_url="https://${INSTANCE_URL}?repo=${REPOSITORY}&key=${KEY_FILE_FOR_DEPLOY}${extra_params}"
             echo "   URL: ${deployment_url}"
             echo ""
             

--- a/src/CustomCommands.php
+++ b/src/CustomCommands.php
@@ -56,6 +56,13 @@ class CustomCommands {
                 return $replacement ?: $matches[0];
             }
 
+            // Fallback: resolve unknown placeholders from query params
+            $value = $this->request->getQueryParam($baseKey);
+            if ($value !== '') {
+                $this->logger->debug("Resolving placeholder {$baseKey} from query param: {$value}");
+                return $value;
+            }
+
             return $matches[0];
         }, $command);
 

--- a/src/Executer.php
+++ b/src/Executer.php
@@ -6,6 +6,7 @@ use Mariano\GitAutoDeploy\views\RanCommand;
 
 class Executer {
     private $configReader;
+    private $request;
     public const EXIT_CODE_TIMEOUT = 124;
 
     public const WHITELISTED_STRINGS = [
@@ -13,8 +14,9 @@ class Executer {
         'echo $PWD',
     ];
 
-    public function __construct(ConfigReader $configReader) {
+    public function __construct(ConfigReader $configReader, Request $request) {
         $this->configReader = $configReader;
+        $this->request = $request;
     }
 
     public function run(string $command, ?callable $outputCallback = null): RanCommand {
@@ -47,7 +49,9 @@ class Executer {
             2 => ['pipe', 'w'],
         ];
 
-        $process = proc_open($command, $descriptorspec, $pipes);
+        $env = $this->buildDeployEnv();
+
+        $process = proc_open($command, $descriptorspec, $pipes, null, null, $env);
 
         if (!is_resource($process)) {
             return [
@@ -192,5 +196,16 @@ class Executer {
 
     private function whoami(): string {
         return exec('whoami');
+    }
+
+    private function buildDeployEnv(): array {
+        $result = array_merge($_SERVER, $_ENV);
+        foreach ($this->request->getQueryParamsAll() as $k => $v) {
+            if (strpos($k, 'env_') === 0) {
+                $name = substr($k, 4); // strip 'env_' prefix
+                $result['DEPLOY_' . strtoupper(str_replace('-', '_', $name))] = $v;
+            }
+        }
+        return $result;
     }
 }

--- a/src/Request.php
+++ b/src/Request.php
@@ -74,6 +74,10 @@ class Request {
         return self::sanitizeQueryparam($value);
     }
 
+    public function getQueryParamsAll(): array {
+        return $this->queryParams;
+    }
+
     public function getBody(): array {
         return $this->body;
     }

--- a/test/ExecuterTest.php
+++ b/test/ExecuterTest.php
@@ -4,12 +4,14 @@ namespace Mariano\GitAutoDeploy\Test;
 
 use Mariano\GitAutoDeploy\ConfigReader;
 use Mariano\GitAutoDeploy\Executer;
+use Mariano\GitAutoDeploy\Request;
 use Mariano\GitAutoDeploy\views\RanCommand;
 use PHPUnit\Framework\TestCase;
 
 class ExecuterTest extends TestCase {
     private $subject;
     private $configMock;
+    private $requestMock;
 
     public function setUp(): void {
         $this->configMock = $this->createMock(ConfigReader::class);
@@ -19,7 +21,11 @@ class ExecuterTest extends TestCase {
                 [ConfigReader::COMMAND_TIMEOUT, 3600], // Default timeout
             ]);
 
-        $this->subject = new Executer($this->configMock);
+        $this->requestMock = $this->createMock(Request::class);
+        $this->requestMock->method('getQueryParam')->willReturn('');
+        $this->requestMock->method('getQueryParamsAll')->willReturn([]);
+
+        $this->subject = new Executer($this->configMock, $this->requestMock);
     }
 
     public function testRunEscapesCommandWithoutWhitelistedStrings(): void {

--- a/test/ExecuterTest.php
+++ b/test/ExecuterTest.php
@@ -75,7 +75,7 @@ class ExecuterTest extends TestCase {
                 [ConfigReader::COMMAND_TIMEOUT, 1], // 1 segundo de timeout (más corto para CI)
             ]);
 
-        $subject = new Executer($this->configMock);
+        $subject = new Executer($this->configMock, $this->requestMock);
 
         // Ejecutar comando que tardará más que el timeout
         // Usar un comando que definitivamente tarda más
@@ -115,7 +115,7 @@ class ExecuterTest extends TestCase {
                 [ConfigReader::COMMAND_TIMEOUT, 10],
             ]);
 
-        $subject = new Executer($this->configMock);
+        $subject = new Executer($this->configMock, $this->requestMock);
         $result = $subject->run('echo "test output"');
 
         $this->assertInstanceOf(RanCommand::class, $result);
@@ -130,7 +130,7 @@ class ExecuterTest extends TestCase {
                 [ConfigReader::COMMAND_TIMEOUT, 10],
             ]);
 
-        $subject = new Executer($this->configMock);
+        $subject = new Executer($this->configMock, $this->requestMock);
 
         // Comando multilínea simple
         $multilineCommand = "if [ 1 -eq 1 ]; then\n  echo 'test multiline'\nfi";
@@ -155,7 +155,7 @@ class ExecuterTest extends TestCase {
                 [ConfigReader::COMMAND_TIMEOUT, 10],
             ]);
 
-        $subject = new Executer($this->configMock);
+        $subject = new Executer($this->configMock, $this->requestMock);
 
         // Comando multilínea más complejo similar al ejemplo del usuario
         $multilineCommand = "if [ ! -d '/tmp/test-dir' ]; then\n  mkdir -p /tmp/test-dir\n  echo 'Directory created'\nfi";

--- a/test/RunnerTest.php
+++ b/test/RunnerTest.php
@@ -828,9 +828,9 @@ class RunnerTest extends TestCase {
             $deployMock
         );
 
-        $executer = new class ($this->mockConfigReader) extends Executer {
-            public function __construct(ConfigReader $configReader) {
-                parent::__construct($configReader);
+        $executer = new class ($this->mockConfigReader, $this->mockRequest) extends Executer {
+            public function __construct(ConfigReader $configReader, Request $request) {
+                parent::__construct($configReader, $request);
             }
 
             public function run(string $command, ?callable $outputCallback = null): \Mariano\GitAutoDeploy\views\RanCommand {


### PR DESCRIPTION
## Summary

Adds support for passing custom environment variables from workflow consumers to deployment commands.

## How it works

Workflow consumers pass `env_vars: "mode=external-only services=notifications"` as an input to the reusable workflow. Each `KEY=VALUE` pair becomes a query param `env_KEY=VALUE` which is then converted to `DEPLOY_KEY=VALUE` environment variables in the deployment commands.

### Consumer example

```yaml
uses: mnofresno/github-autodeploy/.github/workflows/reusable-deploy.yml@master
with:
  env_vars: "mode=external-only services=notifications group-messages-bridge"
  # ... other inputs
```

### Inside .git-auto-deploy.yml

```yaml
post_fetch_commands:
  - |
    if [ "$DEPLOY_mode" = "external-only" ]; then
      docker compose pull $DEPLOY_services
      docker compose up -d --force-recreate $DEPLOY_services
    else
      # normal deploy
    fi
```

## Changes

- **Request.php**: add `getQueryParamsAll()` to expose raw query parameters
- **CustomCommands.php**: fallback to resolve unknown `\{\{ key \}\}\} placeholders from query params
- **Executer.php**: accept `Request`, inject `DEPLOY_*` env vars for `env_*` query params
- **reusable-deploy.yml**: add `env_vars` input, convert to `env_*` query params